### PR TITLE
chore: improve open-source project hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 node_modules
 bun.lock
+.pulse/
+.DS_Store
+*.log
+docs/

--- a/README.ko.md
+++ b/README.ko.md
@@ -64,7 +64,7 @@ curl -s -X POST localhost:3400/notify \
 
 ```bash
 curl localhost:3400/health
-# {"status":"ok"}
+# {"status":"ok","port":3400,"session":"12345"}
 ```
 
 ## 활용 예시
@@ -128,6 +128,7 @@ fi
 | 환경변수 | 기본값 | 설명 |
 |----------|--------|------|
 | `PULSE_PORT` | `3400` | HTTP 서버 포트 |
+| `CLAUDE_CODE_SSE_PORT` | — | Claude Code SSE 포트 (세션 키로 사용) |
 
 ## 제약사항
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ curl -s -X POST localhost:3400/notify \
 
 ```bash
 curl localhost:3400/health
-# {"status":"ok"}
+# {"status":"ok","port":3400,"session":"12345"}
 ```
 
 ## Examples
@@ -128,6 +128,7 @@ fi
 | Env Variable | Default | Description |
 |-------------|---------|-------------|
 | `PULSE_PORT` | `3400` | HTTP server port |
+| `CLAUDE_CODE_SSE_PORT` | — | Claude Code SSE port (used as session key for port file) |
 
 ## Limitations
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,14 @@
 {
   "name": "claude-channel-pulse",
   "version": "0.0.1",
+  "description": "Local HTTP channel for pushing notifications into Claude Code sessions.",
   "license": "MIT",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chsm04/pulse.git"
+  },
+  "homepage": "https://github.com/chsm04/pulse",
   "bin": "./server.ts",
   "scripts": {
     "start": "bun install --no-summary && bun server.ts"

--- a/server.ts
+++ b/server.ts
@@ -5,9 +5,13 @@ import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js'
-import { mkdirSync, writeFileSync, unlinkSync, readdirSync } from 'fs'
+import { mkdirSync, writeFileSync, unlinkSync, readdirSync, readFileSync, statSync } from 'fs'
 import { homedir } from 'os'
-import { join } from 'path'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const pkg = JSON.parse(readFileSync(join(__dirname, 'package.json'), 'utf-8'))
 
 const PORT = Number(process.env.PULSE_PORT ?? 3400)
 const STATE_DIR = join(homedir(), '.pulse')
@@ -29,15 +33,28 @@ function cleanupPort(): void {
   try { unlinkSync(join(STATE_DIR, `${SESSION_KEY}.port`)) } catch {}
 }
 
+const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000 // 24 hours
+
 function cleanupStale(): void {
   try {
     for (const f of readdirSync(STATE_DIR)) {
       if (!f.endsWith('.port')) continue
-      const pid = parseInt(f.replace('.port', ''), 10)
-      if (isNaN(pid)) continue
-      try { process.kill(pid, 0) } catch {
-        // process doesn't exist, remove stale port file
-        try { unlinkSync(join(STATE_DIR, f)) } catch {}
+      const filePath = join(STATE_DIR, f)
+      const key = f.replace('.port', '')
+      const pid = parseInt(key, 10)
+      // PID-based session key: check if process is alive
+      if (!isNaN(pid)) {
+        try { process.kill(pid, 0) } catch {
+          try { unlinkSync(filePath) } catch {}
+        }
+        continue
+      }
+      // Non-PID session key (e.g. SSE port): remove if older than 24h
+      try {
+        const age = Date.now() - statSync(filePath).mtimeMs
+        if (age > STALE_THRESHOLD_MS) unlinkSync(filePath)
+      } catch {
+        try { unlinkSync(filePath) } catch {}
       }
     }
   } catch {}
@@ -48,7 +65,7 @@ process.on('SIGINT', () => { cleanupPort(); process.exit(0) })
 process.on('SIGTERM', () => { cleanupPort(); process.exit(0) })
 
 const mcp = new Server(
-  { name: 'pulse', version: '0.0.1' },
+  { name: 'pulse', version: pkg.version },
   {
     capabilities: {
       tools: {},


### PR DESCRIPTION
## Summary
- `server.ts` 버전을 `package.json`에서 읽도록 변경 (하드코딩 제거)
- `cleanupStale()`에서 SSE 포트 기반 세션키도 24시간 초과 시 정리되도록 개선
- README 영문/한글의 `/health` 응답 예시를 실제 출력과 일치하도록 수정
- `CLAUDE_CODE_SSE_PORT` 환경변수 문서 추가
- `package.json`에 `repository`, `homepage`, `description` 필드 추가
- `.gitignore`에 `.pulse/`, `.DS_Store`, `*.log`, `docs/` 추가

## Test plan
- [x] `bun x tsc --noEmit` 통과
- [ ] `curl localhost:3400/health` 응답 확인
- [ ] 포트 폴백 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)