### PR TITLE
docs: update health response and deprecate SSE_PORT

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -64,7 +64,7 @@ curl -s -X POST localhost:3400/notify \
 
 ```bash
 curl localhost:3400/health
-# {"status":"ok","port":3400,"session":"12345"}
+# {"status":"ok","port":3400,"session":"12345","pid":67890}
 ```
 
 ## 활용 예시
@@ -128,7 +128,7 @@ fi
 | 환경변수 | 기본값 | 설명 |
 |----------|--------|------|
 | `PULSE_PORT` | `3400` | HTTP 서버 포트 |
-| `CLAUDE_CODE_SSE_PORT` | — | Claude Code SSE 포트 (세션 키로 사용) |
+| `CLAUDE_CODE_SSE_PORT` | — | _(deprecated, 무시됨)_ — 세션 키는 Claude Code PID에서 자동 추출 |
 
 ## 제약사항
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ curl -s -X POST localhost:3400/notify \
 
 ```bash
 curl localhost:3400/health
-# {"status":"ok","port":3400,"session":"12345"}
+# {"status":"ok","port":3400,"session":"12345","pid":67890}
 ```
 
 ## Examples
@@ -128,7 +128,7 @@ fi
 | Env Variable | Default | Description |
 |-------------|---------|-------------|
 | `PULSE_PORT` | `3400` | HTTP server port |
-| `CLAUDE_CODE_SSE_PORT` | — | Claude Code SSE port (used as session key for port file) |
+| `CLAUDE_CODE_SSE_PORT` | — | _(deprecated, ignored)_ — session key is now derived from Claude Code PID |
 
 ## Limitations
 


### PR DESCRIPTION
## Summary
- `/health` 응답 예시에 `pid` 필드 추가
- `CLAUDE_CODE_SSE_PORT` deprecated 표기 (세션 키는 이제 Claude Code PID 기반)

## Test plan
- [ ] CI 완료 후 Pulse 알림 수신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)